### PR TITLE
fix: update trl to 0.15.2 for compatibility with transformers 4.51.3

### DIFF
--- a/documents/chapter11/requirements.txt
+++ b/documents/chapter11/requirements.txt
@@ -5,4 +5,4 @@ tqdm==4.67.1
 pandas==2.2.3
 transformers==4.51.3
 datasets==3.5.0
-trl==0.9.4
+trl==0.15.2


### PR DESCRIPTION
## Summary

The `documents/chapter11/requirements.txt` pins `trl==0.9.4` together with `transformers==4.51.3`, which are **incompatible** — TRL 0.9.4 targets Transformers ~4.40 and its internal APIs diverge significantly from 4.46+. This causes import errors when running the RLHF notebook.

This PR updates `trl` to `0.15.2`, which is aligned with the Transformers 4.51.x API.

Closes #36

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>