### PR TITLE
fix: update trl to 0.15.2 for compatibility with transformers 4.51.3

### DIFF
--- a/documents/chapter11/requirements.txt
+++ b/documents/chapter11/requirements.txt
@@ -5,4 +5,4 @@ tqdm==4.67.1
 pandas==2.2.3
 transformers==4.51.3
 datasets==3.5.0
-trl==0.9.4
+trl==0.15.2


### PR DESCRIPTION
## Summary

Update `trl` from `0.9.4` to `0.15.2` in `documents/chapter11/requirements.txt` to fix version incompatibility with `transformers==4.51.3`.

TRL 0.9.4 was released against Transformers ~4.40 and does not support the API changes introduced in Transformers 4.46+. TRL 0.15+ re-aligned with the current Transformers API.

Closes #36